### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# General
+**/.DS_Store
+**/*.md
+**/LICENSE
+
+# Git
+**/.git
+**/.github
+**/.gitattributes
+**/.gitignore
+
+# Docker
+**/.dockerignore
+**/Dockerfile
+
+# Node
+**/node_modules/
+**/dist
+**/npm-debug.log
+
+# Env
+.env
+.env.*
+!.env.example
+
+# Generated certs
+.certs/

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,0 +1,52 @@
+---
+name: Build & Publish Postgis Test
+
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: "0 0 1,15 * *"  # Every 2 weeks
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-publish:
+    name: Build & Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker GitHub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata for the Docker image
+        id: meta
+        uses: docker/metadata-action@5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+ARG NODE_VERSION=lts
+
+#
+# --- Build Stage ---
+#
+
+FROM node:${NODE_VERSION}-alpine as build
+
+# Install dependencies
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm install --frozen-lockfile
+
+# Copy codebase
+COPY . .
+
+#
+# --- Base Stage ---
+#
+
+FROM node:${NODE_VERSION}-alpine as base
+
+USER nobody
+
+# Copy codebase
+WORKDIR /app
+COPY --from=build --chown=nobody /app/package.json /app/index.js ./
+COPY --from=build --chown=nobody /app/node_modules node_modules
+COPY --from=build --chown=nobody /app/src src
+
+# Location of generated SSL certificates
+VOLUME /app/.certs
+
+#
+# --- App Stage ---
+#
+
+FROM base as app
+
+ENV NODE_ENV=production
+COPY --from=build --chown=nobody /app/app.js .
+
+# A comma-separated list of root domains to whitelist
+ENV WHITELIST_HOSTS=
+# A comma-separated list of root domains to blacklist
+ENV BLACKLIST_HOSTS=
+# The URL to redirect to when a blacklisted host is accessed
+ENV BLACKLIST_REDIRECT=
+# The host to enable `/stat` endpoint
+ENV HOME_DOMAIN=
+
+ENV HTTP_PORT=8080 HTTPS_PORT=8443
+EXPOSE 8080 8443
+
+ENTRYPOINT ["node"]
+CMD ["app.js"]


### PR DESCRIPTION
Fixes #16.

## Dockerfile

- Multi-stage build, with 2 final stages, one for each command we want to run (app or stat).
- I've added `ENV`s as needed, with default values corresponding to what I found in the codebase.
- A volume is declared for the `.certs` folder. Docker will create a volume on the fly, but users can provide a local mount point if preferred (see below).
- Everything runs as user `nobody` for better security.

## Build

This adds a dockerfile for hosting both the `app` itself and the `stat` service. You can build it using:
- App: `docker build --tag forward-domain .`
- Stat: `docker build --target=stat --tag forward-domain-stat  .`

To provide a specific `node` version (besides the default `lts`), add ` --build-arg NODE_VERSION=…`.

## Run

Then run it using something like:
```bash
docker run -p 80:8080 -it --env-file .env -v /local-path-to-your/.certs:/app/.certs forward-domain
```

- Make sure to expose the ports you need.
- The env-file argument is optional and should point to an actual file. You can also inject env parameters one by one.
- The volume mount point is recommended so you don't lose data. It should be shared between instances of the `app` and `stat` containers, so the latter can provide accurate information.

## Notes

- I didn't bother adding a target for the development environment as that would involve more dependencies. If anyone wants to tackle that, feel free to do so 😉 
- The name/tags in the build commands are just examples. You probably want something like `forward-domain:version` and `forward-domain:version-stat`. Or maybe not, I honestly don't know which is better.