### PR TITLE
Option to delete the cache for a specific domain via a POST request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "jose": "^5.6.3",
         "lru-cache": "^11.0.0",
         "node-forge": "^1.3.1",
-        "rsa-csr": "^1.0.6"
+        "rsa-csr": "^1.0.6",
+        "validator": "^13.9.0"
       },
       "devDependencies": {
         "@types/bun": "^1.1.6"
@@ -521,6 +522,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "jose": "^5.6.3",
     "lru-cache": "^11.0.0",
     "node-forge": "^1.3.1",
-    "rsa-csr": "^1.0.6"
+    "rsa-csr": "^1.0.6",
+    "validator": "^13.9.0"
   },
   "devDependencies": {
     "@types/bun": "^1.1.6"

--- a/src/client.js
+++ b/src/client.js
@@ -155,8 +155,8 @@ const listener = async function (req, res) {
                                 if (validator.isFQDN(domain)) {
                                     const cacheExists = resolveCache.get(domain);
                                     if (cacheExists !== null && cacheExists !== undefined && cacheExists !== '') {
-                                        // Overwrite the cache for the domain with nothing
-                                        resolveCache.set(domain, ``);
+                                        // Remove the cache entry
+                                        resolveCache.delete(domain);
                                     }
                                 }
                             }

--- a/src/client.js
+++ b/src/client.js
@@ -149,8 +149,11 @@ const listener = async function (req, res) {
                                 const domain = parsedData.domain;
 
                                 if (validator.isFQDN(domain)) {
-                                    // Overwrite the cache for the domain with nothing
-                                    resolveCache.set(domain, ``);
+                                    const cacheExists = resolveCache.get(domain);
+                                    if (cacheExists !== null && cacheExists !== undefined && cacheExists !== '') {
+                                        // Overwrite the cache for the domain with nothing
+                                        resolveCache.set(domain, ``);
+                                    }
                                 }
                             }
                         });

--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,7 @@
 import { LRUCache } from "lru-cache";
 import { client, getStat } from "./sni.js";
+import querystring from 'querystring';
+import validator from 'validator';
 import {
     findTxtRecord,
     isHostBlacklisted,
@@ -11,6 +13,8 @@ import {
     isExceedHostLimit,
     isHttpCodeAllowed
 } from "./util.js";
+
+const MAX_DATA_SIZE = 10 * 1024; // 10 KB
 
 /**
  * @typedef {Object} Cache
@@ -123,7 +127,42 @@ const listener = async function (req, res) {
                     res.writeHead(200, { 'Content-Type': 'text/plain' });
                     res.write("ok");
                     return;
+                case '/flushcache':
+                    if (req.method === 'POST') {
+                        let body = '';
+                        let totalSize = 0;
+
+                        req.on('data', chunk => {
+                            totalSize += chunk.length;
+                            // Disconnect if the data stream is too large
+                            if (totalSize > MAX_DATA_SIZE) {
+                                req.destroy();
+                                return;
+                            }
+
+                            body += chunk.toString();
+                        });
+
+                        req.on('end', () => {
+                            if (totalSize <= MAX_DATA_SIZE) {
+                                const parsedData = querystring.parse(body);
+                                const domain = parsedData.domain;
+
+                                if (validator.isFQDN(domain)) {
+                                    // Overwrite the cache for the domain with nothing
+                                    resolveCache.set(domain, ``);
+                                }
+                            }
+                        });
+                        res.writeHead(200, { 'Content-Type': 'text/plain' });
+                        res.write("Cache cleared");
+                        return;
+                    }
+                    res.writeHead(405, {'Content-Type': 'text/plain'});
+                    res.write("Method Not Allowed");
+                    return;
             }
+
         }
         let cache = resolveCache.get(host);
         if (!cache || (Date.now() > cache.expire)) {

--- a/src/client.js
+++ b/src/client.js
@@ -148,6 +148,10 @@ const listener = async function (req, res) {
                                 const parsedData = querystring.parse(body);
                                 const domain = parsedData.domain;
 
+                                if (!domain) {
+                                    return;
+                                }
+
                                 if (validator.isFQDN(domain)) {
                                     const cacheExists = resolveCache.get(domain);
                                     if (cacheExists !== null && cacheExists !== undefined && cacheExists !== '') {


### PR DESCRIPTION
The `/flushcache` endpoint has been added to clear the cache for a specific domain. This will overwrite the cache with no data. The cache will be automatically rebuilt upon the next HTTP request.

You can clear the cache with a POST request, for example, using curl:

```
curl -X POST http://r.forwarddomain.net/flushcache \
     -H "Content-Type: application/x-www-form-urlencoded" \
     -d "domain=my.example.tld"
```

The data sent may be up to 10 KB in size, and the input is also validated using an FQDN validator.