### PR TITLE
Option to override the default cache TTL of 86400 seconds

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -28,6 +28,7 @@ This guide will walk you through the process of setting up your own instance of 
 `BLACKLIST_REDIRECT` | The URL to redirect to when a blacklisted host is accessed
 `HOME_DOMAIN` | The host to enable `/stat` endpoint
 `USE_LOCAL_DNS` | Default is `false`, so the Google DNS is used. Set it to `true` if you want to use the DNS resolver of your own host
+`CACHE_EXPIRY_SECONDS` | Option to override the default cache TTL of 86400 seconds (1 day)
 
 If `WHITELIST_HOSTS` is set, `BLACKLIST_HOSTS` is ignored. Both is mutually exclusive.
 

--- a/src/client.js
+++ b/src/client.js
@@ -25,6 +25,11 @@ import {
  */
 let resolveCache = new LRUCache({ max: 10000 });
 
+/**
+ * @type {int | 86400}
+ */
+const cacheExpirySeconds = parseInt(process.env.CACHE_EXPIRY_SECONDS, 10) || 86400;
+
 function pruneCache() {
     resolveCache = new LRUCache({ max: 10000 });
 }
@@ -71,7 +76,7 @@ async function buildCache(host) {
         url,
         expand,
         blacklisted: isHostBlacklisted(host),
-        expire: Date.now() + 86400 * 1000,
+        expire: Date.now() + cacheExpirySeconds * 1000,
         httpStatus: parseInt(httpStatus),
     };
 }


### PR DESCRIPTION
Option to override the default cache TTL of 86400 seconds (1 day) through an environment variable.