### PR TITLE
Fix for queryCaa ENODATA when using local DNS

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -203,12 +203,14 @@ export async function validateCAARecords(host, mockResolve = undefined) {
         useLocalDNS = process.env.USE_LOCAL_DNS == 'true';
     }
     let issueRecords;
+    let records;
     if (useLocalDNS && !mockResolve) {
-        const records = await dns.resolveCaa(host);
-        if (!records || records.length === 0) {
+        try {
+            records = mockResolve || await dns.resolveCaa(host);
+        } catch (error) {
             return null;
         }
-
+        
         issueRecords = records.filter(record => record.issue).map(record => `0 issue "${record.issue}"`)
     } else {
         /**

--- a/src/util.js
+++ b/src/util.js
@@ -203,15 +203,10 @@ export async function validateCAARecords(host, mockResolve = undefined) {
         useLocalDNS = process.env.USE_LOCAL_DNS == 'true';
     }
     let issueRecords;
-    let records;
     if (useLocalDNS && !mockResolve) {
-        try {
-            records = mockResolve || await dns.resolveCaa(host);
-        } catch (error) {
-            return null;
-        }
-        
-        issueRecords = records.filter(record => record.issue).map(record => `0 issue "${record.issue}"`)
+        const records = mockResolve || await dns.resolveCaa(host).catch(() => null);
+        issueRecords = (records || []).filter(record => record.issue).map(record => `0 issue "${record.issue}"`);
+
     } else {
         /**
          * @type {{data: {Answer: {data: string, type: number}[]}}}


### PR DESCRIPTION
Improved error handling when retrieving the CAA record. It sometimes failed when you requested a CAA record for a domain that did not have one. This issue did not occur with subdomains for a certain reason.