### PR TITLE
Added debug/logging feature

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -29,6 +29,8 @@ This guide will walk you through the process of setting up your own instance of 
 `HOME_DOMAIN` | The host to enable `/stat` endpoint
 `USE_LOCAL_DNS` | Default is `false`, so the Google DNS is used. Set it to `true` if you want to use the DNS resolver of your own host
 `CACHE_EXPIRY_SECONDS` | Option to override the default cache TTL of 86400 seconds (1 day)
+`DEBUG_MODE` | Default is `false`; set to true to enable debug mode. Messages will be shown in the console
+`DEBUG_LEVEL` | Default level is 1 and can be set up to level 3 for maximum information
 
 If `WHITELIST_HOSTS` is set, `BLACKLIST_HOSTS` is ignored. Both is mutually exclusive.
 

--- a/HOSTING.md
+++ b/HOSTING.md
@@ -29,8 +29,7 @@ This guide will walk you through the process of setting up your own instance of 
 `HOME_DOMAIN` | The host to enable `/stat` endpoint
 `USE_LOCAL_DNS` | Default is `false`, so the Google DNS is used. Set it to `true` if you want to use the DNS resolver of your own host
 `CACHE_EXPIRY_SECONDS` | Option to override the default cache TTL of 86400 seconds (1 day)
-`DEBUG_MODE` | Default is `false`; set to true to enable debug mode. Messages will be shown in the console
-`DEBUG_LEVEL` | Default level is 1 and can be set up to level 3 for maximum information
+`DEBUG_LEVEL` | Default level is 0 (disabled) and can be set up to level 3 for maximum information
 
 If `WHITELIST_HOSTS` is set, `BLACKLIST_HOSTS` is ignored. Both is mutually exclusive.
 

--- a/src/util.js
+++ b/src/util.js
@@ -7,6 +7,7 @@ import forge from "node-forge";
 const recordParamDestUrl = 'forward-domain';
 const recordParamHttpStatus = 'http-status';
 const caaRegex = /^0 issue (")?letsencrypt\.org(;validationmethods=http-01)?\1$/;
+const validDebugLevels = [0, 1, 2, 3];
 
 /**
  * @type {Record<string, boolean>}
@@ -35,10 +36,6 @@ let whitelistMap = null;
  * @type {number | null}
  */
 let cacheExpirySeconds = null;
-/**
- * @type {boolean | null}
- */
-let debugMode = null
 /**
  * @type {number | null}
  */
@@ -104,7 +101,6 @@ export function clearConfig() {
     useLocalDNS = null;
     blacklistRedirectUrl = null;
     cacheExpirySeconds = null;
-    debugMode = null;
     debugLevel = null;
 }
 
@@ -168,29 +164,22 @@ export function CurrentDate() {
 
 /**
  * Outputs debug messages to the console based on the specified debug level.
- * Debugging is controlled by the `DEBUG_MODE` and `DEBUG_LEVEL` environment variables.
+ * Debugging is controlled by the `DEBUG_LEVEL` environment variable.
  *
  * @param {number} level - The debug level of the message (1 - 3).
  * @param {string} msg - The debug message to output.
  * 
  */
 export function debugOutput(level,msg) {
-   if (debugMode === null) {
-     debugMode = process.env.DEBUG_MODE == 'true';
-   }
-   if (debugLevel === null) {
-     debugLevel = process.env.DEBUG_LEVEL || 1;
-   }
-   if (debugMode) {
-     const date = CurrentDate();
-     if (level === 1 && debugLevel === 1 ) {
- 	   console.log(`[${date}] ${msg}`);
-     } else if (level <= 2 && debugLevel <= 2 ) {
- 	   console.log(`[${date}] ${msg}`);
-     } else if (level <=3 & debugLevel <= 3) {
- 	   console.log(`[${date}] ${msg}`);
-     }
-   }
+    if (debugLevel === null) {
+        debugLevel = validDebugLevels.includes(parseInt(process.env.DEBUG_LEVEL)) ? parseInt(process.env.DEBUG_LEVEL) : 0;
+    }
+    if (debugLevel >= 1) {
+        const date = CurrentDate();
+        if (level <=  debugLevel) {
+        console.log(`[${date}] ${msg}`);
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
With this option, you can enable logging/debugging, which will be written to the console.log(). This can be useful if a redirect isn't working correctly, as it allows you to better see what's happening within the application. By default, this function is disabled.

There are 3 debug levels, where level 1 provides the least information and level 3 provides the most.

Example output:
```
[2024-10-31 15:32:46] Received HTTP request for test.domain.tld
[2024-10-31 15:32:46] findTxtRecord for test.domain.tld: forward-domain=https://www.example.com
[2024-10-31 15:32:46] No cache found for test.domain.tld, storing new data
```